### PR TITLE
Fix database path resolution

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,6 +1,11 @@
+from pathlib import Path
 from sqlmodel import create_engine, Session, SQLModel
 
-DATABASE_URL = "sqlite:///../data/tasks.db"
+# Build absolute path to the SQLite database so it works
+# regardless of the current working directory.
+BASE_DIR = Path(__file__).resolve().parents[1]
+DB_PATH = BASE_DIR / "data" / "tasks.db"
+DATABASE_URL = f"sqlite:///{DB_PATH}"
 engine = create_engine(DATABASE_URL, echo=True)
 
 


### PR DESCRIPTION
## Summary
- fix SQLite path resolution in backend

## Testing
- `pytest -q`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68440ccd4c5883228b1626270149edf1